### PR TITLE
Fix the color constant values

### DIFF
--- a/stanfordkarel/stanfordkarel.py
+++ b/stanfordkarel/stanfordkarel.py
@@ -127,19 +127,19 @@ def corner_color_is(color: str) -> bool:
 
 
 # Defined constants for ease of use by students when coloring corners
-RED = "red"
-BLACK = "black"
-CYAN = "cyan"
-DARK_GRAY = "gray30"
-GRAY = "gray55"
-GREEN = "green"
-LIGHT_GRAY = "gray80"
-MAGENTA = "magenta3"
-ORANGE = "orange"
-PINK = "pink"
-WHITE = "snow"
-BLUE = "blue"
-YELLOW = "yellow"
+RED = "Red"
+BLACK = "Black"
+CYAN = "Cyan"
+DARK_GRAY = "Dark Gray"
+GRAY = "Gray"
+GREEN = "Green"
+LIGHT_GRAY = "Light Gray"
+MAGENTA = "Magenta"
+ORANGE = "Orange"
+PINK = "Pink"
+WHITE = "White"
+BLUE = "Blue"
+YELLOW = "Yellow"
 BLANK = ""
 
 


### PR DESCRIPTION
These 14 color constants [listed in the docs](https://compedu.stanford.edu/karel-reader/docs/python/en/chapter9.html) currently can not be used as `paint_corner()` parameters: the `paint_corner(color)` function (`karel_program.py`, line 384) expects the color parameter to match one of the keys of `COLOR_MAP` (defined in `karel_world.py`, line 52).

```
COLOR_MAP = {
	'Red': 'red',
	'Black': 'black',
	'Cyan': 'cyan',
	'Dark Gray': 'gray30',
	'Gray': 'gray55',
	'Green': 'green',
	'Light Gray': 'gray80',
	'Magenta': 'magenta3',
	'Orange': 'orange',
	'Pink': 'pink',
	'White': 'snow',
	'Blue': 'blue',
	'Yellow': 'yellow'
}
```
But those keys do not correspond with the color constant values! That causes error, when trying to run code like `paint_corner(GREEN)`.

I've adjusted the color constant values. I guess, the handling of `BLANK` value also needs fixing, as it's not present in the `COLOR_MAP`.