### PR TITLE
Improve Corner Colors - BLANK enum and restore on reset

### DIFF
--- a/stanfordkarel/__init__.py
+++ b/stanfordkarel/__init__.py
@@ -1,4 +1,4 @@
-from stanfordkarel.stanfordkarel import (  # noqa: F401
+from stanfordkarel.karel_world import (  # noqa: F401
     BLACK,
     BLANK,
     BLUE,
@@ -13,6 +13,8 @@ from stanfordkarel.stanfordkarel import (  # noqa: F401
     RED,
     WHITE,
     YELLOW,
+)
+from stanfordkarel.stanfordkarel import (  # noqa: F401
     beepers_in_bag,
     beepers_present,
     corner_color_is,

--- a/stanfordkarel/karel_ascii.py
+++ b/stanfordkarel/karel_ascii.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from enum import Enum, unique
 from typing import Any, Dict, Iterator, Tuple
 
-from .karel_world import Direction, KarelWorld
+from .karel_world import BLANK, Direction, KarelWorld
 
 CHAR_WIDTH = 5
 HORIZONTAL, VERTICAL = "─", "│"
@@ -33,7 +33,7 @@ class Tile:
             result = "<K>"
         elif self.beepers > 0:
             result = f"<{self.beepers}>"
-        elif self.color:
+        elif self.color != BLANK:
             result = self.color[:3]
         else:
             result = self.value

--- a/stanfordkarel/karel_program.py
+++ b/stanfordkarel/karel_program.py
@@ -20,7 +20,7 @@ Date of Creation: 10/1/2019
 from __future__ import annotations
 
 from .karel_ascii import AsciiKarelWorld, compare_output
-from .karel_world import BLANK, COLOR_MAP, INFINITY, Direction, KarelWorld
+from .karel_world import COLOR_MAP, INFINITY, Direction, KarelWorld
 
 NEXT_DIRECTION_MAP = {
     Direction.NORTH: Direction.WEST,
@@ -392,8 +392,8 @@ class KarelProgram:
                 f"Karel attempted to paint the corner with color {color}, "
                 "which is not valid.",
             )
-        if color != BLANK:
-            self.world.paint_corner(self.avenue, self.street, color)
+
+        self.world.paint_corner(self.avenue, self.street, color)
 
     def corner_color_is(self, color: str) -> bool:
         """

--- a/stanfordkarel/karel_program.py
+++ b/stanfordkarel/karel_program.py
@@ -20,7 +20,7 @@ Date of Creation: 10/1/2019
 from __future__ import annotations
 
 from .karel_ascii import AsciiKarelWorld, compare_output
-from .karel_world import COLOR_MAP, INFINITY, Direction, KarelWorld
+from .karel_world import BLANK, COLOR_MAP, INFINITY, Direction, KarelWorld
 
 NEXT_DIRECTION_MAP = {
     Direction.NORTH: Direction.WEST,
@@ -378,7 +378,7 @@ class KarelProgram:
         This function makes Karel paint its current corner the indicated color.
         This function will raise a KarelException if the indicated color is not one
         of the valid predefined colors. For this list of colors, check the
-        kareldefinitions.py file.
+        stanfordkarel.py file.
 
         Parameters:
             color (str) - The color string specifying which color to paint the corner
@@ -392,7 +392,8 @@ class KarelProgram:
                 f"Karel attempted to paint the corner with color {color}, "
                 "which is not valid.",
             )
-        self.world.paint_corner(self.avenue, self.street, color)
+        if color != BLANK:
+            self.world.paint_corner(self.avenue, self.street, color)
 
     def corner_color_is(self, color: str) -> bool:
         """

--- a/stanfordkarel/karel_world.py
+++ b/stanfordkarel/karel_world.py
@@ -49,20 +49,38 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 INFINITY = -1
+
+# Defined constants for ease of use by students when coloring corners
+BLANK = "Empty"
+RED = "Red"
+BLACK = "Black"
+CYAN = "Cyan"
+DARK_GRAY = "Dark Gray"
+GRAY = "Gray"
+GREEN = "Green"
+LIGHT_GRAY = "Light Gray"
+MAGENTA = "Magenta"
+ORANGE = "Orange"
+PINK = "Pink"
+WHITE = "White"
+BLUE = "Blue"
+YELLOW = "Yellow"
+
 COLOR_MAP = {
-    "Red": "red",
-    "Black": "black",
-    "Cyan": "cyan",
-    "Dark Gray": "gray30",
-    "Gray": "gray55",
-    "Green": "green",
-    "Light Gray": "gray80",
-    "Magenta": "magenta3",
-    "Orange": "orange",
-    "Pink": "pink",
-    "White": "snow",
-    "Blue": "blue",
-    "Yellow": "yellow",
+    BLANK: "",
+    BLACK: "black",
+    BLUE: "blue",
+    CYAN: "cyan",
+    DARK_GRAY: "gray30",
+    GRAY: "gray55",
+    GREEN: "green",
+    LIGHT_GRAY: "gray80",
+    MAGENTA: "magenta3",
+    ORANGE: "orange",
+    PINK: "pink",
+    RED: "red",
+    WHITE: "snow",
+    YELLOW: "yellow",
 }
 INIT_SPEED = 50
 VALID_WORLD_KEYWORDS = [

--- a/stanfordkarel/karel_world.py
+++ b/stanfordkarel/karel_world.py
@@ -109,7 +109,7 @@ class KarelWorld:
         # Map of beeper locations to the count of beepers at that location
         self.beepers: dict[tuple[int, int], int] = {}
 
-        # Map of corner colors, defaults to ""
+        # Map of corner colors
         self.corner_colors: dict[tuple[int, int], str] = {}
 
         # Set of Wall objects placed in the world
@@ -133,6 +133,12 @@ class KarelWorld:
 
         # Save initial beeper state to enable world reset
         self.init_beepers = copy.deepcopy(self.beepers)
+
+        # Fill corner colors
+        for ave in range(1, 1 + self.num_avenues):
+            for st in range(1, 1 + self.num_streets):
+                if (ave, st) not in self.corner_colors:
+                    self.corner_colors[(ave, st)] = BLANK
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, KarelWorld):
@@ -375,7 +381,7 @@ class KarelWorld:
 
         # Next, output all color information
         for (x, y), color in sorted(self.corner_colors.items()):
-            if color:
+            if color is not BLANK:
                 output += f"Color: ({x}, {y}); {color}\n"
 
         # Next, output Karel information

--- a/stanfordkarel/karel_world.py
+++ b/stanfordkarel/karel_world.py
@@ -140,6 +140,8 @@ class KarelWorld:
                 if (ave, st) not in self.corner_colors:
                     self.corner_colors[(ave, st)] = BLANK
 
+        self.init_corner_colors = copy.deepcopy(self.corner_colors)
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, KarelWorld):
             return (
@@ -341,13 +343,11 @@ class KarelWorld:
         self.corner_colors[(avenue, street)] = color
 
     def corner_color(self, avenue: int, street: int) -> str:
-        if (avenue, street) in self.corner_colors:
-            return self.corner_colors[(avenue, street)]
-        return ""
+        return self.corner_colors[(avenue, street)]
 
     def reset_corner(self, avenue: int, street: int) -> None:
         self.beepers[(avenue, street)] = 0
-        self.corner_colors[(avenue, street)] = ""
+        self.corner_colors[(avenue, street)] = BLANK
 
     def wall_exists(self, avenue: int, street: int, direction: Direction) -> bool:
         wall = Wall(avenue, street, direction)
@@ -359,7 +359,7 @@ class KarelWorld:
     def reset_world(self) -> None:
         """Reset initial state of beepers in the world"""
         self.beepers = copy.deepcopy(self.init_beepers)
-        self.corner_colors = {}
+        self.corner_colors = copy.deepcopy(self.init_corner_colors)
 
     def reload_world(self, filename: str | None = None) -> None:
         """Reloads world using constructor."""

--- a/stanfordkarel/stanfordkarel.py
+++ b/stanfordkarel/stanfordkarel.py
@@ -123,23 +123,6 @@ def corner_color_is(color: str) -> bool:
     return True
 
 
-# Defined constants for ease of use by students when coloring corners
-RED = "Red"
-BLACK = "Black"
-CYAN = "Cyan"
-DARK_GRAY = "Dark Gray"
-GRAY = "Gray"
-GREEN = "Green"
-LIGHT_GRAY = "Light Gray"
-MAGENTA = "Magenta"
-ORANGE = "Orange"
-PINK = "Pink"
-WHITE = "White"
-BLUE = "Blue"
-YELLOW = "Yellow"
-BLANK = ""
-
-
 def run_karel_program(world_file: str = "") -> None:
     # Extract the name of the file the student is executing
     student_code_file = Path(sys.argv[0])

--- a/tests/karel_world_test.py
+++ b/tests/karel_world_test.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from stanfordkarel.karel_application import StudentCode
 from stanfordkarel.karel_program import KarelProgram
+from stanfordkarel.karel_world import BLANK
 
 STONE_MASON_ASCII_OUTPUT = (
     "┌───────────────────────────────────────────────────────────────────────────────┐",
@@ -130,6 +131,14 @@ class TestKarelWorld:
     @staticmethod
     def test_equal_worlds() -> None:
         test_program = KarelProgram("1x1")
+        ref_program = KarelProgram("1x1")
+
+        assert ref_program.world == test_program.world
+
+    @staticmethod
+    def test_paint_corner() -> None:
+        test_program = KarelProgram("1x1")
+        test_program.paint_corner(BLANK)
         ref_program = KarelProgram("1x1")
 
         assert ref_program.world == test_program.world

--- a/tests/karel_world_test.py
+++ b/tests/karel_world_test.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from stanfordkarel.karel_application import StudentCode
 from stanfordkarel.karel_program import KarelProgram
-from stanfordkarel.karel_world import BLANK
+from stanfordkarel.karel_world import BLANK, RED
 
 STONE_MASON_ASCII_OUTPUT = (
     "┌───────────────────────────────────────────────────────────────────────────────┐",
@@ -136,9 +136,19 @@ class TestKarelWorld:
         assert ref_program.world == test_program.world
 
     @staticmethod
-    def test_paint_corner() -> None:
+    def test_paint_corner_blank() -> None:
         test_program = KarelProgram("1x1")
         test_program.paint_corner(BLANK)
+        ref_program = KarelProgram("1x1")
+
+        assert ref_program.world == test_program.world
+
+    @staticmethod
+    def test_corner_color_world_reset() -> None:
+        test_program = KarelProgram("1x1")
+        test_program.paint_corner(RED)
+        test_program.world.reset_world()
+
         ref_program = KarelProgram("1x1")
 
         assert ref_program.world == test_program.world


### PR DESCRIPTION
Change Summary:
1. Color definitions have been centralised
2. Modified the `BLANK` constant to have a non None value to resolve equality checks
3. The world `corner_colors` dictionary is now auto-filled with `BLANK` when corner color not provided
4. Painting `BLANK` corner color is now supported
5. Initial corner color state is restored when calling `reset_world`

Added associated tests for new functionality.

This PR resolves the following issues:
1. https://github.com/TylerYep/stanfordkarel/issues/74
2. https://github.com/TylerYep/stanfordkarel/issues/75
