### PR TITLE
Always use light mode in macOS

### DIFF
--- a/stanfordkarel/karel_application.py
+++ b/stanfordkarel/karel_application.py
@@ -11,6 +11,7 @@ Date of Creation: 10/1/2019
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import inspect
 import tkinter as tk
@@ -173,6 +174,12 @@ class KarelApplication(tk.Frame):
     ) -> None:
         # set window background to contrast white Karel canvas
         master.configure(background=LIGHT_GREY)
+
+        # disable dark mode in macOS to maintain legibility (#8)
+        with contextlib.suppress(tk.TclError):
+            master.tk.call(
+                "tk::unsupported::MacWindowStyle", "appearance", str(master), "aqua"
+            )
 
         # configure location of canvas to expand to fit window resizing
         master.rowconfigure(0, weight=1)

--- a/stanfordkarel/world_editor.py
+++ b/stanfordkarel/world_editor.py
@@ -11,6 +11,7 @@ Date of Creation: 10/1/2019
 
 from __future__ import annotations
 
+import contextlib
 import tkinter as tk
 from pathlib import Path
 from tkinter import messagebox, simpledialog
@@ -47,6 +48,12 @@ class WorldBuilderApplication(tk.Frame):
     ) -> None:
         # set window background to contrast white Karel canvas
         master.configure(background=LIGHT_GREY)
+
+        # disable dark mode in macOS to maintain legibility (#8)
+        with contextlib.suppress(tk.TclError):
+            master.tk.call(
+                "tk::unsupported::MacWindowStyle", "appearance", str(master), "aqua"
+            )
 
         # configure location of canvas to expand to fit window resizing
         master.rowconfigure(0, weight=1)


### PR DESCRIPTION
**Describe the bug**

On macOS, Tcl/Tk widgets adopt different colors when the user enables dark mode. Because various parts of _stanfordkarel_'s interface are not designed to respond to these changes, some elements become indistinguishable from their backgrounds, and the program cannot be used. This has been reported by various users in the replies to #8, though the issue originally described appears unrelated.

<img width="912" height="740" alt="Screenshot 2025-08-25 at 23 03 39" src="https://github.com/user-attachments/assets/8f9b00e8-72b8-404b-90c5-2d6ef7105a59" />

**Possible solutions**

- _stanfordkarel_ could be changed to support a dark mode on all platforms, and use that appearance when the user's system requests it.
- _stanfordkarel_ could individually configure default widgets to always use light theme colors.
- _stanfordkarel_ could try to disable dark theming on macOS.

**Proposed solution**

I have attempted the last solution. There is little documentation related to achieving this effect using `tkinter` online. In https://tkdocs.com/tutorial/windows.html, under the heading _Other macOS-Specific Attributes_, there's a description of a command, "::tk::unsupported::MacWindowStyle". (For information on the command's lack of support, see the note at the end of that section.) It links to another page, https://wiki.tcl-lang.org/page/MacWindowStyle, that seems to describe a feature of "tk::unsupported::MacWindowStyle" that cannot be used to set a light or dark theme. However, a separate page under the same domain, https://wiki.tcl-lang.org/page/Tk+differences+on+Mac+OS+X, reads:

> The command tk::unsupported::MacWindowStyle appearance window ?newAppearance? allows a window to be always dark, always light, or respond to the preferences setting.

I tested this approach on my computer, and it's what's implemented in this PR.

**Result**

User interface elements can again be distinguished, even with dark mode enabled on macOS.

<img width="1123" height="554" alt="Screenshot 2025-08-25 at 23 19 34" src="https://github.com/user-attachments/assets/4b673f19-53a6-4d9f-ab65-421c2143ded3" />
