### PR TITLE
Fix add_beeper function

### DIFF
--- a/stanfordkarel/karel_world.py
+++ b/stanfordkarel/karel_world.py
@@ -300,7 +300,7 @@ class KarelWorld:
         self.karel_start_beeper_count = beeper_count
 
     def add_beeper(self, avenue: int, street: int) -> None:
-        self.beepers[(avenue, street)] += 1
+        self.beepers[(avenue, street)] = self.beepers.get((avenue, street), 0) + 1
 
     def remove_beeper(self, avenue: int, street: int) -> None:
         if self.beepers[(avenue, street)] > 0:


### PR DESCRIPTION
For some reason my app is crashing when I trying to use put_beeper on initially empty spot. 
I found that problem was with getting default value in add_beeper function, where I used 0 as default value if it was empty in dictionary